### PR TITLE
Cria imagem Docker para o app

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,32 @@ Crie seu arquivo de propriedade `src/main/resources/application-custom.yml` e ro
 gradle bootRun -Dspring.profiles.active=custom
 ```
 
+## Usando imagem Docker
+Para gerar a imagem Docker do projeto, execute: 
+```
+gradle buildDocker
+```
+
+Por padrão, o nome da imagem será `concretesolutions/mock-api:VERSAO`.
+
+Para rodar a aplicação, crie dois diretórios: um contendo o arquivo de configuração `application-custom.yml` e o outro contendo os arquivos de mock. Execute então:
+
+```
+docker run -d --name mock-api \
+       -p 9090:9090 \
+       -v /path/para/arquivo/application-custom.yml:/config/application.yml \
+       -v /path/para/diretorio/dados/:/data \
+       concretesolutions/mock-api:VERSAO
+```
+
+A porta `9090` expõe o serviço enquanto a porta `5000` é utilizada para debug da aplicação.
+
+Para visualizar os logs da aplicação a partir do container: `docker logs -f mock-api`
+
 ## TODO
-* Adicionar a opção de fazer build com Docker
 * Separar testes unitários dos testes integrados
 * Corrigir os testes ignorados
 * Corrigir Code Style
-* Adcionar plugin do FindBugs
+* Adicionar plugin do FindBugs
 * Revisar dependências (ver, por exemplo, se é mesmo necessário ter o GSON ou modelmapper)
 * Usar objectmapper como component: `compile('com.fasterxml.jackson.datatype:jackson-datatype-jdk8')`

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ buildscript {
     }
     dependencies {
         classpath("org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}")
+        classpath('se.transmode.gradle:gradle-docker:1.2')
     }
 }
 
@@ -14,6 +15,7 @@ apply plugin: 'java'
 apply plugin: 'eclipse'
 apply plugin: 'org.springframework.boot'
 apply plugin: 'jacoco'
+apply plugin: 'docker'
 
 version = '4.0.0-SNAPSHOT'
 sourceCompatibility = 1.8
@@ -21,7 +23,6 @@ sourceCompatibility = 1.8
 repositories {
     mavenCentral()
 }
-
 
 dependencies {
     compile('org.springframework.boot:spring-boot-starter')
@@ -54,5 +55,18 @@ task codeCoverageReport(type: JacocoReport) {
         xml.destination "${buildDir}/reports/jacoco/report.xml"
         html.enabled false
         csv.enabled false
+    }
+}
+
+
+task buildDocker(type: Docker, dependsOn: build) {
+    push = false
+    applicationName = 'concretesolutions/' + jar.baseName
+    dockerfile = file('src/main/docker/Dockerfile')
+    doFirst {
+        copy {
+            from jar
+            into stageDir
+        }
     }
 }

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -1,4 +1,5 @@
 FROM frolvlad/alpine-oraclejdk8:slim
+MAINTAINER "Concrete <cs-chapter-java@concrete.com.br>"
 
 VOLUME /config
 VOLUME /data

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -1,0 +1,16 @@
+FROM frolvlad/alpine-oraclejdk8:slim
+
+VOLUME /config
+VOLUME /data
+
+WORKDIR /
+
+EXPOSE 5000
+EXPOSE 9090
+
+COPY mock-api-*.jar app.jar
+ENTRYPOINT ["java", \
+            "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5000 -Djava.security.egd=file:/dev/./urandom", \
+            "-jar", \
+            "/app.jar", \
+            "--spring.config.location=file:/config/application.yml"]


### PR DESCRIPTION
Permite os usuários da aplicação gerar uma imagem Docker da mock-api e apontar para seu arquivo de configuração e dados de maneira simplificada.